### PR TITLE
Fix #39 - Fix typo where `_WIZCHIP_` was written as `__WIZCHIP_` in two places in wizchip_conf.c

### DIFF
--- a/Ethernet/wizchip_conf.c
+++ b/Ethernet/wizchip_conf.c
@@ -439,7 +439,7 @@ int8_t wizchip_init(uint8_t* txsize, uint8_t* rxsize)
 
 		for(i = 0 ; i < _WIZCHIP_SOCK_NUM_; i++)
 		{
-		#if __WIZCHIP_ < W5200	//2016.10.28 peter add condition for w5100 and w5100s
+		#if _WIZCHIP_ < W5200	//2016.10.28 peter add condition for w5100 and w5100s
 			j = 0;
 			while(txsize[i] >> j != 1){j++;}
 			setSn_TXBUF_SIZE(i, j);
@@ -473,7 +473,7 @@ int8_t wizchip_init(uint8_t* txsize, uint8_t* rxsize)
 
 		for(i = 0 ; i < _WIZCHIP_SOCK_NUM_; i++)
 		{
-		#if __WIZCHIP_ < W5200	//2016.10.28 peter add condition for w5100 and w5100s
+		#if _WIZCHIP_ < W5200	//2016.10.28 peter add condition for w5100 and w5100s
 			j = 0;
 			while(rxsize[i] >> j != 1){j++;}
 			setSn_RXBUF_SIZE(i, j);


### PR DESCRIPTION
See Issue #39 - I did a text search for `__WIZCHIP_` just to be sure, and these were the only two places it turned up.