### PR TITLE
Remove redundant blocking in "MQTTClient.c"

### DIFF
--- a/Internet/MQTT/MQTTClient.c
+++ b/Internet/MQTT/MQTTClient.c
@@ -295,14 +295,10 @@ int MQTTYield(MQTTClient* c, int timeout_ms)
     TimerInit(&timer);
     TimerCountdownMS(&timer, timeout_ms);
 
-	do
+    if (cycle(c, &timer) == FAILURE)
     {
-        if (cycle(c, &timer) == FAILURE)
-        {
-            rc = FAILURE;
-            break;
-        }
-	} while (!TimerIsExpired(&timer));
+        rc = FAILURE;
+    }
         
     return rc;
 }


### PR DESCRIPTION
When I was transfering files using MQTT protocal , there always losing some packet.
Because the timer both used in "MQTTYield" method and "cycle" method , it has a certain chance that the remaining time of timer is not enough to complete the "cycle" method whitch is recieved "PUB" packet and going to send a "ACK" packet.
The problem was soloved after I removed the redundant blocking.