### PR TITLE
fixed unused variables warning

### DIFF
--- a/Ethernet/wizchip_conf.c
+++ b/Ethernet/wizchip_conf.c
@@ -834,7 +834,6 @@ int8_t wizphy_setphypmode(uint8_t pmode)
 
 void wizchip_setnetinfo(wiz_NetInfo* pnetinfo)
 {
-	int i,j,k;
    setSHAR(pnetinfo->mac);
    setGAR(pnetinfo->gw);
    setSUBR(pnetinfo->sn);


### PR DESCRIPTION
removed unused variables in wizchip_setnetinfo.