### PR TITLE
fixed several warnings in mqtt_interface

### DIFF
--- a/Internet/MQTT/mqtt_interface.c
+++ b/Internet/MQTT/mqtt_interface.c
@@ -42,6 +42,7 @@
 
 #include "mqtt_interface.h"
 #include "wizchip_conf.h"
+#include "socket.h"
 
 unsigned long MilliTimer;
 
@@ -122,12 +123,15 @@ void NewNetwork(Network* n, int sn) {
  *         that contains the configuration information for the Network.
  *         buffer : pointer to a read buffer.
  *         len : buffer length.
+ * @retval received data length or SOCKERR code
  */
 int w5x00_read(Network* n, unsigned char* buffer, int len, long time)
 {
 
 	if((getSn_SR(n->my_socket) == SOCK_ESTABLISHED) && (getSn_RX_RSR(n->my_socket)>0))
 		return recv(n->my_socket, buffer, len);
+
+	return SOCK_ERROR;
 }
 
 /*
@@ -136,11 +140,14 @@ int w5x00_read(Network* n, unsigned char* buffer, int len, long time)
  *         that contains the configuration information for the Network.
  *         buffer : pointer to a read buffer.
  *         len : buffer length.
+ * @retval length of data sent or SOCKERR code
  */
 int w5x00_write(Network* n, unsigned char* buffer, int len, long time)
 {
 	if(getSn_SR(n->my_socket) == SOCK_ESTABLISHED)
 		return send(n->my_socket, buffer, len);
+
+	return SOCK_ERROR;
 }
 
 /*
@@ -160,7 +167,7 @@ void w5x00_disconnect(Network* n)
  *         ip : server iP.
  *         port : server port.
  */
-int ConnectNetwork(Network* n, char* ip, int port)
+void ConnectNetwork(Network* n, uint8_t* ip, uint16_t port)
 {
 	uint16_t myport = 12345;
 

--- a/Internet/MQTT/mqtt_interface.h
+++ b/Internet/MQTT/mqtt_interface.h
@@ -212,6 +212,8 @@ int main(void)
 #ifndef __MQTT_INTERFACE_H_
 #define __MQTT_INTERFACE_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern ¡°C¡± {
 #endif
@@ -260,7 +262,7 @@ int w5x00_read(Network*, unsigned char*, int, long);
 int w5x00_write(Network*, unsigned char*, int, long);
 void w5x00_disconnect(Network*);
 void NewNetwork(Network* n, int sn);
-int ConnectNetwork(Network*, char*, int);
+void ConnectNetwork(Network* n, uint8_t* ip, uint16_t port);
 
 #ifdef __cplusplus
 }

--- a/Internet/MQTT/mqtt_interface.h
+++ b/Internet/MQTT/mqtt_interface.h
@@ -215,7 +215,7 @@ int main(void)
 #include <stdint.h>
 
 #ifdef __cplusplus
-extern ¡°C¡± {
+extern "C" {
 #endif
 
 
@@ -241,8 +241,8 @@ typedef struct Network Network;
 struct Network
 {
 	int my_socket;
-	int (*mqttread) (Network*, unsigned char*, int, int);
-	int (*mqttwrite) (Network*, unsigned char*, int, int);
+	int (*mqttread) (Network*, unsigned char*, int, long);
+	int (*mqttwrite) (Network*, unsigned char*, int, long);
 	void (*disconnect) (Network*);
 };
 


### PR DESCRIPTION
fixes all the warnings described in #59 .

- added return values to w5x00_write and w5x00_read.
- changed return value of ConnectNetwork to void.
- changed argument types of ConnectNetwork to align with lower level functions being called
- included socket.h to clean up implicit declaration warnings