### PR TITLE
Fix MQTTClient unaligned access on ARM when using -Os

### DIFF
--- a/Internet/MQTT/MQTTPacket/src/MQTTSubscribe.h
+++ b/Internet/MQTT/MQTTPacket/src/MQTTSubscribe.h
@@ -19,14 +19,14 @@
 #define MQTTSUBSCRIBE_H_
 
 #if !defined(DLLImport)
-  #define DLLImport 
+  #define DLLImport
 #endif
 #if !defined(DLLExport)
   #define DLLExport
 #endif
 
 DLLExport int MQTTSerialize_subscribe(unsigned char* buf, int buflen, unsigned char dup, unsigned short packetid,
-		int count, MQTTString topicFilters[], int requestedQoSs[]);
+		int count, MQTTString topicFilters[], char requestedQoSs[]);
 
 DLLExport int MQTTDeserialize_subscribe(unsigned char* dup, unsigned short* packetid,
 		int maxcount, int* count, MQTTString topicFilters[], int requestedQoSs[], unsigned char* buf, int len);

--- a/Internet/MQTT/MQTTPacket/src/MQTTSubscribeClient.c
+++ b/Internet/MQTT/MQTTPacket/src/MQTTSubscribeClient.c
@@ -48,7 +48,7 @@ int MQTTSerialize_subscribeLength(int count, MQTTString topicFilters[])
   * @return the length of the serialized data.  <= 0 indicates error
   */
 int MQTTSerialize_subscribe(unsigned char* buf, int buflen, unsigned char dup, unsigned short packetid, int count,
-		MQTTString topicFilters[], int requestedQoSs[])
+		MQTTString topicFilters[], char requestedQoSs[])
 {
 	unsigned char *ptr = buf;
 	MQTTHeader header = {0};


### PR DESCRIPTION
QoS value was an enum and this value was passed to MQTTSerialize_subscribe as an (int*).
So when -Os optimization is used the QoS enum was set to byte and placed at odd address.
But when the code reached MQTTSerialize_subscribe and the address of pointer to byte was casted to pointer to integer the LDR instruction caused HardFaul because of unaligned int access.

Fixed by forcing to pass char so now it should not matter which compiler is used.

https://twitter.com/hubmartin/status/1158827784317407232