### PR TITLE
Fix regression KEEPALIVEAUTO Not supported in W5100, W5200

### DIFF
--- a/Ethernet/socket.c
+++ b/Ethernet/socket.c
@@ -858,7 +858,7 @@ int8_t  setsockopt(uint8_t sn, sockopt_type sotype, void* arg)
          		}
             }
          break;
-   #if _WIZCHIP_ > 5100
+   #if !( (_WIZCHIP_ == 5100) || (_WIZCHIP_ == 5200) )
       case SO_KEEPALIVEAUTO:
          CHECK_SOCKMODE(Sn_MR_TCP);
          setSn_KPALVTR(sn,*(uint8_t*)arg);

--- a/Ethernet/socket.h
+++ b/Ethernet/socket.h
@@ -390,7 +390,7 @@ typedef enum
    SO_DESTPORT,         ///< Set the destination Port number. @ref Sn_DPORT ( @ref setSn_DPORT(), @ref getSn_DPORT() )
 #if _WIZCHIP_ != 5100   
    SO_KEEPALIVESEND,    ///< Valid only in setsockopt. Manually send keep-alive packet in TCP mode, Not supported in W5100
-   #if _WIZCHIP_ > 5100   
+   #if !( (_WIZCHIP_ == 5100) || (_WIZCHIP_ == 5200) )
       SO_KEEPALIVEAUTO, ///< Set/Get keep-alive auto transmission timer in TCP mode, Not supported in W5100, W5200
    #endif      
 #endif


### PR DESCRIPTION
Chip W5100s support KEEPALIVEAUTO and this commit c2356c8777b86bb5eb00a5d6e941ed8f0958c4b5 add it (this break code for W5200)

But it not supported in W5100, W5200.

We shuld use:
`#if !( (_WIZCHIP_ == 5100) || (_WIZCHIP_ == 5200) )`