### PR TITLE
Added a break to remove compiler warning.

### DIFF
--- a/Ethernet/socket.c
+++ b/Ethernet/socket.c
@@ -117,6 +117,7 @@ int8_t socket(uint8_t sn, uint8_t protocol, uint16_t port, uint8_t flag)
             uint32_t taddr;
             getSIPR((uint8_t*)&taddr);
             if(taddr == 0) return SOCKERR_SOCKINIT;
+	    break;
          }
       case Sn_MR_UDP :
       case Sn_MR_MACRAW :


### PR DESCRIPTION
Compiler warned that there was no break at the end of the case statement. Added the break.