### PR TITLE
Improve documentation for socket(...)

### DIFF
--- a/Ethernet/W5300/w5300.h
+++ b/Ethernet/W5300/w5300.h
@@ -1014,9 +1014,24 @@ extern "C" {
  */                
 #define Sn_MR_PPPoE        0x05                 /**< Protocol bits of \ref Sn_MR. */
 
-#define SOCK_STREAM        Sn_MR_TCP            /**< For Berkeley Socket API, Refer to @ref Sn_MR_TCP */
-#define SOCK_DGRAM         Sn_MR_UDP            /**< For Berkeley Socket API, Refer to @ref Sn_MR_UDP */
+/* Sn_MR alternate values */
+/**
+ * @brief Reliable connection-oriented byte stream communication (TCP).
+ * @details For Berkeley Socket API compatibility.
+ */
+#define SOCK_STREAM                  Sn_MR_TCP
 
+/**
+ * @brief Unreliable connectionless datagram communication (UDP).
+ * @details For Berkeley Socket API compatibility.
+ */
+#define SOCK_DGRAM                   Sn_MR_UDP
+
+/**
+ * @brief Raw access to the transport protocol.
+ * @details For Berkeley Socket API compatibility.
+ */
+#define SOCK_RAW                     Sn_MR_IPRAW
 
 
 /******************************/ 

--- a/Ethernet/W5500/w5500.h
+++ b/Ethernet/W5500/w5500.h
@@ -915,14 +915,22 @@ extern "C" {
 
 /* Sn_MR alternate values */
 /**
- * @brief For Berkeley Socket API
+ * @brief Reliable connection-oriented byte stream communication (TCP).
+ * @details For Berkeley Socket API compatibility.
  */
 #define SOCK_STREAM                  Sn_MR_TCP
 
 /**
- * @brief For Berkeley Socket API
+ * @brief Unreliable connectionless datagram communication (UDP).
+ * @details For Berkeley Socket API compatibility.
  */
 #define SOCK_DGRAM                   Sn_MR_UDP
+
+/**
+ * @brief Raw access to the transport protocol.
+ * @details For Berkeley Socket API compatibility.
+ */
+#define SOCK_RAW                     Sn_MR_IPRAW
 
 
 /* Sn_CR values */

--- a/Ethernet/socket.h
+++ b/Ethernet/socket.h
@@ -151,7 +151,7 @@
  * @details Initializes the socket with 'sn' passed as parameter and open.
  *
  * @param sn Socket number. It should be <b>0 ~ @ref \_WIZCHIP_SOCK_NUM_</b>.
- * @param protocol Protocol type to operate such as TCP, UDP and MACRAW.
+ * @param protocol Protocol type to operate, such as @ref SOCK_STREAM, @ref SOCK_DGRAM or @ref SOCK_RAW.
  * @param port Port number to be bined.
  * @param flag Socket flags as \ref SF_ETHER_OWN, \ref SF_IGMP_VER2, \ref SF_TCP_NODELAY, \ref SF_MULTI_ENABLE, \ref SF_IO_NONBLOCK and so on.\n
  *             Valid flags only in W5500 : @ref SF_BROAD_BLOCK, @ref SF_MULTI_BLOCK, @ref SF_IPv6_BLOCK, and @ref SF_UNI_BLOCK.


### PR DESCRIPTION
This seeks to make it more clear which values are permissible for the protocol field.
Also defines SOCK_RAW for use with Berkley sockets syntax.

The doxygen would have to be run again after this.