### PR TITLE
There is now the option to supply the DHCP hostname to DHCP_init rath…

### DIFF
--- a/Internet/DHCP/dhcp.c
+++ b/Internet/DHCP/dhcp.c
@@ -214,7 +214,13 @@ uint32_t DHCP_XID;      // Any number
 
 RIP_MSG* pDHCPMSG;      // Buffer pointer for DHCP processing
 
-uint8_t HOST_NAME[] = DCHP_HOST_NAME;  
+/* The host name to send with DHCP requests may either be hard-coded in
+ * DCHP_HOST_NAME or supplied to DHCP_init. */
+#ifdef DCHP_HOST_NAME
+uint8_t HOST_NAME[] = DCHP_HOST_NAME;
+#else
+char  *HOST_NAME = 0;
+#endif
 
 uint8_t DHCP_CHADDR[6]; // DHCP Client MAC address.
 
@@ -289,6 +295,31 @@ void reg_dhcp_cbfunc(void(*ip_assign)(void), void(*ip_update)(void), void(*ip_co
    if(ip_assign)   dhcp_ip_assign = ip_assign;
    if(ip_update)   dhcp_ip_update = ip_update;
    if(ip_conflict) dhcp_ip_conflict = ip_conflict;
+}
+
+/* Some code common to send_DHCP_DISCOVER and send_DHCP_REQUEST. */
+uint16_t pack_host_name(uint16_t k)
+{
+   uint8_t i;
+   pDHCPMSG->OPT[k++] = hostName;
+   pDHCPMSG->OPT[k++] = 0;          // fill zero length of hostname
+   for(i = 0 ; HOST_NAME[i] != 0; i++)
+   {
+      pDHCPMSG->OPT[k++] = HOST_NAME[i];
+   }
+   // `i` is now the length of HOST_NAME
+   #ifdef APPEND_MAC_TO_DHCP_HOST_NAME
+   pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[3] >> 4);
+   pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[3]);
+   pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[4] >> 4);
+   pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[4]);
+   pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[5] >> 4);
+   pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[5]);
+   pDHCPMSG->OPT[k - (i+6+1)] = i+6; // length of hostname
+   #else
+   pDHCPMSG->OPT[k - (i+0+1)] = i+0; // length of hostname
+   #endif
+   return k;
 }
 
 /* make the common DHCP message */
@@ -385,18 +416,7 @@ void send_DHCP_DISCOVER(void)
 	pDHCPMSG->OPT[k++] = DHCP_CHADDR[4];
 	pDHCPMSG->OPT[k++] = DHCP_CHADDR[5];
 	
-	// host name
-	pDHCPMSG->OPT[k++] = hostName;
-	pDHCPMSG->OPT[k++] = 0;          // fill zero length of hostname 
-	for(i = 0 ; HOST_NAME[i] != 0; i++)
-   	pDHCPMSG->OPT[k++] = HOST_NAME[i];
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[3] >> 4); 
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[3]);
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[4] >> 4); 
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[4]);
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[5] >> 4); 
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[5]);
-	pDHCPMSG->OPT[k - (i+6+1)] = i+6; // length of hostname
+   k = pack_host_name(k);
 
 	pDHCPMSG->OPT[k++] = dhcpParamRequest;
 	pDHCPMSG->OPT[k++] = 0x06;	// length of request
@@ -488,17 +508,7 @@ void send_DHCP_REQUEST(void)
 	}
 
 	// host name
-	pDHCPMSG->OPT[k++] = hostName;
-	pDHCPMSG->OPT[k++] = 0; // length of hostname
-	for(i = 0 ; HOST_NAME[i] != 0; i++)
-   	pDHCPMSG->OPT[k++] = HOST_NAME[i];
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[3] >> 4); 
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[3]);
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[4] >> 4); 
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[4]);
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[5] >> 4); 
-	pDHCPMSG->OPT[k++] = NibbleToHex(DHCP_CHADDR[5]);
-	pDHCPMSG->OPT[k - (i+6+1)] = i+6; // length of hostname
+   k = pack_host_name(k);
 	
 	pDHCPMSG->OPT[k++] = dhcpParamRequest;
 	pDHCPMSG->OPT[k++] = 0x08;
@@ -927,8 +937,16 @@ int8_t check_DHCP_leasedIP(void)
 	}
 }	
 
+
+#ifdef DCHP_HOST_NAME
 void DHCP_init(uint8_t s, uint8_t * buf)
+#else
+void DHCP_init(uint8_t s, uint8_t * buf, char *hostname)
+#endif
 {
+   #ifndef DCHP_HOST_NAME
+   HOST_NAME = hostname;
+   #endif
    uint8_t zeroip[4] = {0,0,0,0};
    getSHAR(DHCP_CHADDR);
    if((DHCP_CHADDR[0] | DHCP_CHADDR[1]  | DHCP_CHADDR[2] | DHCP_CHADDR[3] | DHCP_CHADDR[4] | DHCP_CHADDR[5]) == 0x00)

--- a/Internet/DHCP/dhcp.h
+++ b/Internet/DHCP/dhcp.h
@@ -71,6 +71,9 @@ extern "C" {
 #define MAGIC_COOKIE             0x63825363  ///< You should not modify it number.
 
 #define DCHP_HOST_NAME           "WIZnet\0"
+/* If APPEND_MAC_TO_DHCP_HOST_NAME is defined then the last three octets of the
+ * MAC address are appended to the host name supplied with DHCP requests. */
+#define APPEND_MAC_TO_DHCP_HOST_NAME
 
 /* 
  * @brief return value of @ref DHCP_run()
@@ -87,10 +90,15 @@ enum
 
 /*
  * @brief DHCP client initialization (outside of the main loop)
- * @param s   - socket number
- * @param buf - buffer for processing DHCP message
+ * @param s        - socket number
+ * @param buf      - buffer for processing DHCP message
+ * @param hostname - the host name to send with DHCP requests
  */
+#ifdef DCHP_HOST_NAME
 void DHCP_init(uint8_t s, uint8_t * buf);
+#else
+void DHCP_init(uint8_t s, uint8_t * buf, char *hostname);
+#endif
 
 /*
  * @brief DHCP 1s Tick Timer handler


### PR DESCRIPTION
…er than hard-coding in dhcp.h, so that the hostname can be stored in EEPROM for example, and the option to not append the last three octets of the MAC address to the DHCP hostname