### PR TITLE
Added Vendor Class Identifier in DHCP offers and requests.

### DIFF
--- a/Internet/DHCP/dhcp.c
+++ b/Internet/DHCP/dhcp.c
@@ -214,6 +214,8 @@ uint32_t DHCP_XID;      // Any number
 
 RIP_MSG* pDHCPMSG;      // Buffer pointer for DHCP processing
 
+uint8_t VENDOR_ID[] = DHCP_VENDOR_ID;
+
 uint8_t HOST_NAME[] = DCHP_HOST_NAME;  
 
 uint8_t DHCP_CHADDR[6]; // DHCP Client MAC address.
@@ -374,6 +376,13 @@ void send_DHCP_DISCOVER(void)
 	pDHCPMSG->OPT[k++] = 0x01;
 	pDHCPMSG->OPT[k++] = DHCP_DISCOVER;
 	
+	// Class identifier
+	pDHCPMSG->OPT[k++] = dhcpClassIdentifier;
+	pDHCPMSG->OPT[k++] = 0;          // fill zero length for class identifier
+	for(i = 0 ; VENDOR_ID[i] != 0; i++)
+	   	pDHCPMSG->OPT[k++] = VENDOR_ID[i];
+	pDHCPMSG->OPT[k - (i+1)] = i;
+
 	// Client identifier
 	pDHCPMSG->OPT[k++] = dhcpClientIdentifier;
 	pDHCPMSG->OPT[k++] = 0x07;
@@ -460,6 +469,14 @@ void send_DHCP_REQUEST(void)
 	pDHCPMSG->OPT[k++] = 0x01;
 	pDHCPMSG->OPT[k++] = DHCP_REQUEST;
 
+	// Class identifier
+	pDHCPMSG->OPT[k++] = dhcpClassIdentifier;
+	pDHCPMSG->OPT[k++] = 0;          // fill zero length for class identifier
+	for(i = 0 ; VENDOR_ID[i] != 0; i++)
+	   	pDHCPMSG->OPT[k++] = VENDOR_ID[i];
+	pDHCPMSG->OPT[k - (i+1)] = i;
+
+	// Client identifier
 	pDHCPMSG->OPT[k++] = dhcpClientIdentifier;
 	pDHCPMSG->OPT[k++] = 0x07;
 	pDHCPMSG->OPT[k++] = 0x01;

--- a/Internet/DHCP/dhcp.h
+++ b/Internet/DHCP/dhcp.h
@@ -70,6 +70,8 @@ extern "C" {
 
 #define MAGIC_COOKIE             0x63825363  ///< You should not modify it number.
 
+#define DHCP_VENDOR_ID           "WIZnetSE\0"  ///< Vendor ID used for DHCP requests, using Class-Id (option 60)
+
 #define DCHP_HOST_NAME           "WIZnet\0"
 
 /* 


### PR DESCRIPTION
The Vendor Class Identifier is a constant string that identifies the
kind of hardware that asks the DHCP server for a IP address. The ID is
passed via the option 60 of the DHCP messages.

The ID is set to "WIZnetSE" constant.

From a DHCP server point of view, this ID is useful for giving specific
configuration for Wiznet modules : IP address from different address
pool, different gateway, longer lease, etc.

Reference documentation :
https://datatracker.ietf.org/doc/html/rfc2132#section-9.13