### PR TITLE
Fix the W5500 PHY configuration

### DIFF
--- a/Ethernet/W5500/w5500.h
+++ b/Ethernet/W5500/w5500.h
@@ -768,7 +768,7 @@ extern "C" {
 #define PHYCFGR_OPMDC_ALLA           (7<<3)
 #define PHYCFGR_OPMDC_PDOWN          (6<<3)
 #define PHYCFGR_OPMDC_NA             (5<<3)
-#define PHYCFGR_OPMDC_100FA          (4<<3)
+#define PHYCFGR_OPMDC_100HA          (4<<3)
 #define PHYCFGR_OPMDC_100F           (3<<3)
 #define PHYCFGR_OPMDC_100H           (2<<3)
 #define PHYCFGR_OPMDC_10F            (1<<3)

--- a/Ethernet/wizchip_conf.c
+++ b/Ethernet/wizchip_conf.c
@@ -749,13 +749,26 @@ void wizphy_reset(void)
 
 void wizphy_setphyconf(wiz_PhyConf* phyconf)
 {
-   uint8_t tmp = 0;
+   uint8_t tmp = getPHYCFGR() & ~(PHYCFGR_RST);
    if(phyconf->by == PHY_CONFBY_SW)
       tmp |= PHYCFGR_OPMD;
    else
       tmp &= ~PHYCFGR_OPMD;
    if(phyconf->mode == PHY_MODE_AUTONEGO)
-      tmp |= PHYCFGR_OPMDC_ALLA;
+   {
+        /* For the W5500, 100BT-HDX is the only valid speed+duplex config
+    	 * that can be paired with auto-negotiation */
+    	if (phyconf->speed == PHY_SPEED_100 && phyconf->duplex == PHY_DUPLEX_HALF)
+    	{
+    		tmp |= PHYCFGR_OPMDC_100HA;
+    	}
+    	else
+    	{
+    		/* For all other combinations, ignore them as garbage
+    		 * and simply enable All Modes with auto-negotiation */
+    		tmp |= PHYCFGR_OPMDC_ALLA;
+    	}
+   }
    else
    {
       if(phyconf->duplex == PHY_DUPLEX_FULL)
@@ -785,7 +798,7 @@ void wizphy_getphyconf(wiz_PhyConf* phyconf)
    switch(tmp & PHYCFGR_OPMDC_ALLA)
    {
       case PHYCFGR_OPMDC_ALLA:
-      case PHYCFGR_OPMDC_100FA: 
+      case PHYCFGR_OPMDC_100HA: 
          phyconf->mode = PHY_MODE_AUTONEGO;
          break;
       default:
@@ -794,7 +807,7 @@ void wizphy_getphyconf(wiz_PhyConf* phyconf)
    }
    switch(tmp & PHYCFGR_OPMDC_ALLA)
    {
-      case PHYCFGR_OPMDC_100FA:
+      case PHYCFGR_OPMDC_100HA:
       case PHYCFGR_OPMDC_100F:
       case PHYCFGR_OPMDC_100H:
          phyconf->speed = PHY_SPEED_100;
@@ -805,7 +818,6 @@ void wizphy_getphyconf(wiz_PhyConf* phyconf)
    }
    switch(tmp & PHYCFGR_OPMDC_ALLA)
    {
-      case PHYCFGR_OPMDC_100FA:
       case PHYCFGR_OPMDC_100F:
       case PHYCFGR_OPMDC_10F:
          phyconf->duplex = PHY_DUPLEX_FULL;


### PR DESCRIPTION
Not sure there's any activity still happening in this repo, so this is more for anyone else who runs into the same PHY configuration issue.

This commit fixes the following:

* Whenever the application specifies `PHY_MODE_AUTONEGO` in the `wizphy_setphyconf` argument, the function would unconditionally configure the PHY for "All Modes Capable". This is not quite in line with the datasheet, which permits 100BT+HDX to be paired with Auto-Negotiation.
* `PHYCFGR_OPMDC_100FA` seems to have been misnamed all this time -- it should've been called `PHYCFGR_OPMDC_100HA` since the Auto-negotiation is paired with 100BT-**H**DX, not 100BT-FDX.
* When reading the current PHY conf in `wizphy_getphyconf`, the above misnaming meant that the function would incorrectly return 100BT-FDX + Auto-nego, when the real conf is actually 100BT-HDX + Auto-Nego.
* Avoid unintentional PHY reset when setting the configuration -- this is done by masking all but the RST bit of the PHYCFGR, when assembling the bits for the requested configuration. 