### PR TITLE
Added support for recv timeout feature

### DIFF
--- a/Ethernet/socket.h
+++ b/Ethernet/socket.h
@@ -388,6 +388,7 @@ typedef enum
    SO_MSS,              ///< Set MSS. @ref Sn_MSSR ( @ref setSn_MSSR(), @ref getSn_MSSR() )
    SO_DESTIP,           ///< Set the destination IP address. @ref Sn_DIPR ( @ref setSn_DIPR(), @ref getSn_DIPR() )
    SO_DESTPORT,         ///< Set the destination Port number. @ref Sn_DPORT ( @ref setSn_DPORT(), @ref getSn_DPORT() )
+   SO_RCVTIMEO,			///< Set the timeout for recv() function, by default it is infinite or wait forever
 #if _WIZCHIP_ != 5100   
    SO_KEEPALIVESEND,    ///< Valid only in setsockopt. Manually send keep-alive packet in TCP mode, Not supported in W5100
    #if !( (_WIZCHIP_ == 5100) || (_WIZCHIP_ == 5200) )

--- a/Ethernet/wizchip_conf.c
+++ b/Ethernet/wizchip_conf.c
@@ -281,6 +281,11 @@ void reg_wizchip_spiburst_cbfunc(void (*spi_rb)(uint8_t* pBuf, uint16_t len), vo
    }
 }
 
+void reg_wizchip_tick_cbfunc(uint32_t (*_get_tick) (void))
+{
+	WIZCHIP._get_tick = _get_tick;
+}
+
 int8_t ctlwizchip(ctlwizchip_type cwtype, void* arg)
 {
 #if	_WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5500

--- a/Ethernet/wizchip_conf.h
+++ b/Ethernet/wizchip_conf.h
@@ -249,7 +249,13 @@ typedef struct __WIZCHIP
    {
       void (*_select)  (void);      ///< @ref \_WIZCHIP_ selected
       void (*_deselect)(void);      ///< @ref \_WIZCHIP_ deselected
-   }CS;  
+   }CS;
+
+   /**
+    * A function to get current one millisecond tick
+    */
+   uint32_t (*_get_tick) (void);
+
    /**
     * The set of interface IO callback func.
     */
@@ -505,6 +511,16 @@ void reg_wizchip_spi_cbfunc(uint8_t (*spi_rb)(void), void (*spi_wb)(uint8_t wb))
 void reg_wizchip_spiburst_cbfunc(void (*spi_rb)(uint8_t* pBuf, uint16_t len), void (*spi_wb)(uint8_t* pBuf, uint16_t len));
 
 /**
+ * @brief Registers call back function to get one millisecond tick counter value.
+ * @details Resets WIZCHIP & internal PHY, Configures PHY mode, Monitor PHY(Link,Speed,Half/Full/Auto),
+ * controls interrupt & mask and so on.
+ * @param _get_tick : callback function to get one millisecond tick counter value
+ * @param arg : arg type is dependent on cwtype.
+ *
+ */
+void reg_wizchip_tick_cbfunc(uint32_t (*_get_tick) (void));
+
+/**
  * @ingroup extra_functions
  * @brief Controls to the WIZCHIP.
  * @details Resets WIZCHIP & internal PHY, Configures PHY mode, Monitor PHY(Link,Speed,Half/Full/Auto),
@@ -512,7 +528,7 @@ void reg_wizchip_spiburst_cbfunc(void (*spi_rb)(uint8_t* pBuf, uint16_t len), vo
  * @param cwtype : Decides to the control type
  * @param arg : arg type is dependent on cwtype.
  * @return  0 : Success \n
- *         -1 : Fail because of invalid \ref ctlwizchip_type or unsupported \ref ctlwizchip_type in WIZCHIP 
+ *         -1 : Fail because of invalid \ref ctlwizchip_type or unsupported \ref ctlwizchip_type in WIZCHIP
  */          
 int8_t ctlwizchip(ctlwizchip_type cwtype, void* arg);
 


### PR DESCRIPTION
I have added a feature to support timeout in **recv()** call. We can now use the **setsockopt()** with option **SO_RCVTIMEO** to set timeout value for the specified socket. To get access to a one millisecond counter, I have extended the WIZCHIP stuct to have a new function pointer _get_tick() which should return the value of one ms tick counter. On STM32 platform I connect this to the HAL_GetTick() function. 