### PR TITLE
const correct MQTT APIs to enable compiling with C++

### DIFF
--- a/Internet/MQTT/MQTTClient.c
+++ b/Internet/MQTT/MQTTClient.c
@@ -133,9 +133,9 @@ exit:
 // + and # can only be next to separator
 static char isTopicMatched(char* topicFilter, MQTTString* topicName)
 {
-    char* curf = topicFilter;
-    char* curn = topicName->lenstring.data;
-    char* curn_end = curn + topicName->lenstring.len;
+    const char* curf = topicFilter;
+    const char* curn = topicName->lenstring.data;
+    const char* curn_end = curn + topicName->lenstring.len;
 
     while (*curf && curn < curn_end)
     {
@@ -145,7 +145,7 @@ static char isTopicMatched(char* topicFilter, MQTTString* topicName)
             break;
         if (*curf == '+')
         {   // skip until we meet the next separator, or end of string
-            char* nextpos = curn + 1;
+            const char* nextpos = curn + 1;
             while (nextpos < curn_end && *nextpos != '/')
                 nextpos = ++curn + 1;
         }

--- a/Internet/MQTT/MQTTClient.h
+++ b/Internet/MQTT/MQTTClient.h
@@ -71,7 +71,7 @@ typedef struct MQTTMessage
     unsigned char retained;
     unsigned char dup;
     unsigned short id;
-    void *payload;
+    const void *payload;
     size_t payloadlen;
 } MQTTMessage;
 

--- a/Internet/MQTT/MQTTPacket/src/MQTTPacket.c
+++ b/Internet/MQTT/MQTTPacket/src/MQTTPacket.c
@@ -257,11 +257,11 @@ int MQTTstrlen(MQTTString mqttstring)
  * @param bptr the C string to compare
  * @return boolean - equal or not
  */
-int MQTTPacket_equals(MQTTString* a, char* bptr)
+int MQTTPacket_equals(MQTTString* a, const char* bptr)
 {
 	int alen = 0,
 		blen = 0;
-	char *aptr;
+	const char *aptr;
 	
 	if (a->cstring)
 	{

--- a/Internet/MQTT/MQTTPacket/src/MQTTPacket.h
+++ b/Internet/MQTT/MQTTPacket/src/MQTTPacket.h
@@ -75,12 +75,12 @@ typedef union
 typedef struct
 {
 	int len;
-	char* data;
+	const char* data;
 } MQTTLenString;
 
 typedef struct
 {
-	char* cstring;
+	const char* cstring;
 	MQTTLenString lenstring;
 } MQTTString;
 
@@ -98,7 +98,7 @@ int MQTTSerialize_ack(unsigned char* buf, int buflen, unsigned char type, unsign
 int MQTTDeserialize_ack(unsigned char* packettype, unsigned char* dup, unsigned short* packetid, unsigned char* buf, int buflen);
 
 int MQTTPacket_len(int rem_len);
-int MQTTPacket_equals(MQTTString* a, char* b);
+int MQTTPacket_equals(MQTTString* a, const char* b);
 
 int MQTTPacket_encode(unsigned char* buf, int length);
 int MQTTPacket_decode(int (*getcharfn)(unsigned char*, int), int* value);


### PR DESCRIPTION
Compiling with C++ still requires putting `extern "C"` around the includes, but previously it was just not possible to compile MQTT into a C++ project