### PR TITLE
Add functionality to reset flag isConnected if keepalive is failing.

### DIFF
--- a/Internet/MQTT/MQTTClient.c
+++ b/Internet/MQTT/MQTTClient.c
@@ -212,6 +212,12 @@ int keepalive(MQTTClient* c)
             int len = MQTTSerialize_pingreq(c->buf, c->buf_size);
             if (len > 0 && (rc = sendPacket(c, len, &timer)) == SUCCESSS) // send the ping packet
                 c->ping_outstanding = 1;
+            else
+                c->isconnected = 0;
+        }
+        else
+        {
+           	c->isconnected = 0;
         }
     }
 


### PR DESCRIPTION
This change should handle the situation that if MQTT client is connected to MQTT broker, and doesn't receive feedback from the broker during keep alive handling, that the flag isConnected is set back to 0. By having this an application has better knowledge by checking the flag, if still connected to the broker and can react. 

In current implementation, what I tested, the application cannot detect this, and trying to publish new messages will fail.