### PR TITLE
Fixing snmp compiler warnings

### DIFF
--- a/Ethernet/socket.c
+++ b/Ethernet/socket.c
@@ -196,8 +196,8 @@ inline uint8_t inline_CheckAddrlen_W6x00(void) {
 
 int8_t socket(uint8_t sn, uint8_t protocol, uint16_t port, uint8_t flag) {
 
-    uint8_t taddr[16];
-    uint16_t local_port = 0;
+    //uint8_t taddr[16];
+    //uint16_t local_port = 0;
     CHECK_SOCKNUM();
     switch (protocol & 0x0F) {
 #ifdef IPV6_AVAILABLE
@@ -1033,6 +1033,7 @@ static int32_t recvfrom_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * 
         while (getSn_CR(sn));
 
 #else
+        (void)addrlen; // Unused
         if (sock_remained_size[sn] == 0) {
             wiz_recv_data(sn, head, 8);
             setSn_CR(sn, Sn_CR_RECV);

--- a/Ethernet/socket.c
+++ b/Ethernet/socket.c
@@ -59,6 +59,11 @@
 //#define SOCK_ANY_PORT_NUM  0xC000;
 #define SOCK_ANY_PORT_NUM  0xC000
 
+// Static prototypes
+static int8_t connect_IO_6(uint8_t sn, uint8_t * addr, uint16_t port, uint8_t addrlen);
+static int32_t sendto_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port, uint8_t addrlen);
+static int32_t recvfrom_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port, uint8_t *addrlen);
+
 static uint16_t sock_any_port = SOCK_ANY_PORT_NUM;
 static uint16_t sock_io_mode = 0;
 static uint16_t sock_is_sending = 0;

--- a/Ethernet/socket.h
+++ b/Ethernet/socket.h
@@ -311,7 +311,7 @@ int8_t  listen(uint8_t sn);
          In block io mode, it does not return until connection is completed. \n
          In Non-block io mode(@ref SF_IO_NONBLOCK), it returns @ref SOCK_BUSY immediately.
 */
-static int8_t connect_IO_6(uint8_t sn, uint8_t * addr, uint16_t port, uint8_t addrlen);
+//static int8_t connect_IO_6(uint8_t sn, uint8_t * addr, uint16_t port, uint8_t addrlen);
 //int8_t connect(uint8_t sn, uint8_t * addr, uint16_t port, uint8_t addrlen);
 
 /**
@@ -401,7 +401,7 @@ int32_t recv(uint8_t sn, uint8_t * buf, uint16_t len);
          In non-block io mode(@ref SF_IO_NONBLOCK), It return @ref SOCK_BUSY immediately when SOCKET transimttable buffer size is not enough.
 */
 //int32_t sendto(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port, uint8_t addrlen);
-static int32_t sendto_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port, uint8_t addrlen);
+//static int32_t sendto_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t port, uint8_t addrlen);
 
 /**
     @ingroup WIZnet_socket_APIs
@@ -436,7 +436,7 @@ static int32_t sendto_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * ad
          In non-block io mode(@ref SF_IO_NONBLOCK), it return @ref SOCK_BUSY immediately when SOCKET RX buffer is empty. \n
 */
 //int32_t recvfrom(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port, uint8_t *addrlen);
-static int32_t recvfrom_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port, uint8_t *addrlen);
+//static int32_t recvfrom_IO_6(uint8_t sn, uint8_t * buf, uint16_t len, uint8_t * addr, uint16_t *port, uint8_t *addrlen);
 
 
 /////////////////////////////

--- a/Ethernet/wizchip_conf.c
+++ b/Ethernet/wizchip_conf.c
@@ -127,7 +127,7 @@ void 	wizchip_bus_writedata(uint32_t AddrSel, iodata_t wb)  {
     @sa wizchip_bus_write_buf()
 */
 void wizchip_bus_read_buf(uint32_t AddrSel, iodata_t* buf, int16_t len, uint8_t addrinc) {
-    uint16_t i;
+    int16_t i;
     if (addrinc) {
         addrinc = sizeof(iodata_t);
     }
@@ -151,7 +151,7 @@ void wizchip_bus_read_buf(uint32_t AddrSel, iodata_t* buf, int16_t len, uint8_t 
     @sa wizchip_bus_read_buf()
 */
 void wizchip_bus_write_buf(uint32_t AddrSel, iodata_t* buf, int16_t len, uint8_t addrinc) {
-    uint16_t i;
+    int16_t i;
     if (addrinc) {
         addrinc = sizeof(iodata_t);
     }
@@ -179,7 +179,7 @@ uint8_t wizchip_spi_readbyte(void)        {
     null function is called.
 */
 //void 	wizchip_spi_writebyte(uint8_t wb) {};
-void 	wizchip_spi_writebyte(uint8_t wb) {}
+void 	wizchip_spi_writebyte(uint8_t wb) { (void)wb; }
 
 /**
     @brief Default function to burst read in SPI interface.
@@ -221,14 +221,14 @@ void 	wizchip_spi_writeburst(uint8_t* pBuf, uint16_t len) {}
     @note This function help not to access wrong address. If you do not describe this function or register any functions,
     null function is called.
 */
-void wizchip_qspi_read(uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len) {}
+void wizchip_qspi_read(uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len) { (void)opcode; (void)addr; (void)pBuf; (void)len; }
 
 /**
     @brief Default function to write in QSPI interface.
     @note This function help not to access wrong address. If you do not describe this function or register any functions,
     null function is called.
 */
-void wizchip_qspi_write(uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len) {}
+void wizchip_qspi_write(uint8_t opcode, uint16_t addr, uint8_t* pBuf, uint16_t len) { (void)opcode; (void)addr; (void)pBuf; (void)len; }
 
 #endif
 /**
@@ -270,7 +270,9 @@ _WIZCHIP  WIZCHIP = {
             //wizchip_bus_readbyte,
             //wizchip_bus_writebyte
             wizchip_bus_readdata,
-            wizchip_bus_writedata
+            wizchip_bus_writedata,
+            NULL,
+            NULL
         },
 
     }

--- a/Internet/SNMP/snmp.c
+++ b/Internet/SNMP/snmp.c
@@ -3,6 +3,7 @@
 #include <ctype.h>
 #include <stdarg.h>
 #include <time.h>
+#include <inttypes.h>
 
 #include "socket.h"
 #include "snmp.h"
@@ -146,7 +147,7 @@ int32_t snmpd_run(void) {
 
     uint8_t svr_addr[6];
     uint16_t  svr_port;
-#if 1
+#if ((_WIZCHIP_ == 6100) || (_WIZCHIP_ == 6300))
     // 20231019 taylor
     uint8_t addr_len;
 #endif
@@ -713,7 +714,8 @@ void ipToByteArray(int8_t *ip, uint8_t *pDes) {
         }
     }
 
-    sscanf((char const*)buff, "%u %u %u %u", &ip1, &ip2, &ip3, &ip4);
+    //sscanf((char const*)buff, "%u %u %u %u", &ip1, &ip2, &ip3, &ip4);
+    sscanf((char const*)buff, "%" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32, &ip1, &ip2, &ip3, &ip4);
     pDes[0] = ip1; pDes[1] = ip2; pDes[2] = ip3; pDes[3] = ip4;
 }
 

--- a/Internet/SNMP/snmp.c
+++ b/Internet/SNMP/snmp.c
@@ -26,10 +26,10 @@ void insertRespLen(int32_t reqStart, int32_t respStart, int32_t size);
 int32_t parseVarBind(int32_t reqType, int32_t index);
 int32_t parseSequence(int32_t reqType, int32_t index);
 int32_t parseSequenceOf(int32_t reqType);
-int32_t parseRequest();
-int32_t parseCommunity();
-int32_t parseVersion();
-int32_t parseSNMPMessage();
+int32_t parseRequest(void);
+int32_t parseCommunity(void);
+int32_t parseVersion(void);
+int32_t parseSNMPMessage(void);
 
 // Debugging function
 #ifdef _SNMP_DEBUG_

--- a/Internet/SNMP/snmp_custom.h
+++ b/Internet/SNMP/snmp_custom.h
@@ -22,7 +22,7 @@ extern const int32_t maxData;
 #define COMMUNITY_SIZE				(strlen(COMMUNITY))
 
 /* Predefined function: Response value control */
-void initTable();
+void initTable(void);
 
 /* User defined functions: LED control examples */
 #ifdef _USE_WIZNET_W5500_EVB_


### PR DESCRIPTION
There were two minor compiler warnings -- one was from a variable that is only used on two chips. The fix was to just escape that declaration with the same #if that includes the code for that chip. The second was the use of %u in a scan for a uint32_t variable. On compilers that %u is not 32-bit, this is a warning. Instead, inttypes.h is used so you get PRIu32 which represents "whatever printf format represents uint32_t".