### PR TITLE
fix: validate recvfrom() return before indexing into buf (AUD-001)

### DIFF
--- a/Application/loopback/loopback.c
+++ b/Application/loopback/loopback.c
@@ -249,14 +249,14 @@ int32_t loopback_udpc(uint8_t sn, uint8_t* buf, uint8_t* destip, uint16_t destpo
                 size = DATA_BUF_SIZE;
             }
             ret = recvfrom(sn, buf, size, destip, (uint16_t*)&destport);
-            buf[ret] = 0x00;
-            printf("recv form[%d.%d.%d.%d][%d]: %s\n", destip[0], destip[1], destip[2], destip[3], destport, buf);
             if (ret <= 0) {
 #ifdef _LOOPBACK_DEBUG_
                 printf("%d: recvfrom error. %ld\r\n", sn, ret);
 #endif
                 return ret;
             }
+            buf[ret] = 0x00;
+            printf("recv form[%d.%d.%d.%d][%d]: %s\n", destip[0], destip[1], destip[2], destip[3], destport, buf);
             size = (uint16_t) ret;
             sentsize = 0;
             while (sentsize != size) {


### PR DESCRIPTION
## Summary

Fixes out-of-bounds write in `loopback_udpc()` where `buf[ret] = 0x00` was executed before checking whether `ret <= 0`.

## Problem

In `Application/loopback/loopback.c:247-254`, the UDP client loopback executed:
```c
ret = recvfrom(sn, buf, size, destip, (uint16_t*)&destport);
buf[ret] = 0x00;                    // OOB if ret < 0 or ret == DATA_BUF_SIZE
printf("recv form[...]: %s\n", ...);
if (ret <= 0) { return ret; }       // check comes too late
```

- `ret == DATA_BUF_SIZE` writes one byte past the buffer (stack-buffer-overflow under ASan)
- Negative returns (e.g. `SOCKERR_SOCKCLOSED = -13`) index before the buffer (stack-buffer-underflow)

## Fix

Move the `ret <= 0` check before `buf[ret] = 0x00` and `printf()`, preserving both after the guard.

## Verification

- Multi-chip compile check: passes for all 7 `_WIZCHIP_` values
- ASan/UBSan: host harness with mocked `recvfrom()` returning `DATA_BUF_SIZE`, `-13`, and `0` — no sanitizer abort