### PR TITLE
fix: use uint8_t* for SO_KEEPALIVEAUTO getter (AUD-002)

### DIFF
--- a/Ethernet/socket.c
+++ b/Ethernet/socket.c
@@ -1380,7 +1380,7 @@ int8_t getsockopt(uint8_t sn, sockopt_type sotype, void* arg) {
 #if  _WIZCHIP_ > 5200
     case SO_KEEPALIVEAUTO:
         CHECK_TCPMODE();
-        *(uint16_t*) arg = getSn_KPALVTR(sn);
+        *(uint8_t*) arg = getSn_KPALVTR(sn);
         break;
 #endif
     case SO_SENDBUF:


### PR DESCRIPTION
## Summary

Fixes type-width mismatch in the `SO_KEEPALIVEAUTO` socket option getter.

## Problem

`Ethernet/socket.c:1383` wrote the keepalive auto value through `uint16_t*`:
```c
*(uint16_t*) arg = getSn_KPALVTR(sn);
```

But the setter at `socket.c:1334` and the documented type at `socket.h:583` both use `uint8_t`. A conforming caller passing `uint8_t value` has one adjacent byte overwritten and may trigger an unaligned halfword fault on strict-alignment MCUs.

## Fix

Change `uint16_t*` to `uint8_t*`:
```c
*(uint8_t*) arg = getSn_KPALVTR(sn);
```

## Verification

- Multi-chip compile check: passes for all 7 `_WIZCHIP_` values
- ASan/UBSan: canary test confirms exactly 1 byte written, adjacent bytes intact