### PR TITLE
fix: initialize SPI callback union member for SPI-mode builds (AUD-003)

### DIFF
--- a/Ethernet/wizchip_conf.c
+++ b/Ethernet/wizchip_conf.c
@@ -264,6 +264,16 @@ _WIZCHIP  WIZCHIP = {
         wizchip_cs_select,
         wizchip_cs_deselect
     },
+#if (_WIZCHIP_IO_MODE_ & _WIZCHIP_IO_MODE_SPI_)
+    {
+        .SPI = {
+            ._read_byte   = wizchip_spi_readbyte,
+            ._write_byte  = wizchip_spi_writebyte,
+            ._read_burst  = 0,
+            ._write_burst = 0
+        }
+    }
+#else
     {
         {
             //M20150601 : Rename the function
@@ -274,6 +284,7 @@ _WIZCHIP  WIZCHIP = {
         },
 
     }
+#endif
 };
 
 


### PR DESCRIPTION
## Summary

Fixes incompatible callback initialization in the `WIZCHIP` global for SPI-mode builds.

## Problem

The `WIZCHIP` global initializer at `Ethernet/wizchip_conf.c:256-277` only initialized the `IF.BUS` union member (`iodata_t (*)(uint32_t)` signatures), even when `_WIZCHIP_IO_MODE_` selected SPI mode. W5500 register access calls through `IF.SPI._read_byte` (`uint8_t (*)(void)`) and `IF.SPI._write_byte` (`void (*)(uint8_t)`) — incompatible function signatures through the wrong union member. Any W5500 access before SPI callback registration could HardFault or corrupt memory on common ARM ABIs.

## Fix

Add `#if (_WIZCHIP_IO_MODE_ & _WIZCHIP_IO_MODE_SPI_)` conditional around the union initializer:
- **SPI mode**: initialize `IF.SPI` with `wizchip_spi_readbyte` (returns 0), `wizchip_spi_writebyte` (no-op), and NULL burst callbacks
- **BUS mode**: keep existing `IF.BUS._read_data`/`_write_data` initialization under `#else`

## Verification

- Multi-chip compile check: passes for all 7 `_WIZCHIP_` values
- The existing `wizchip_spi_readbyte`/`wizchip_spi_writebyte` stubs at `wizchip_conf.c:172-182` are reused