### PR TITLE
fix: check recvsize before nonblocking mode in TCP recv() (AUD-004)

### DIFF
--- a/Ethernet/socket.c
+++ b/Ethernet/socket.c
@@ -684,11 +684,11 @@ int32_t recv(uint8_t sn, uint8_t * buf, uint16_t len) { //lihan
                 return SOCK_BUSY;
             }
 #else
-            if (sock_io_mode & (1 << sn)) {
-                return SOCK_BUSY;
-            }
             if (recvsize != 0) {
                 break;
+            }
+            if (sock_io_mode & (1 << sn)) {
+                return SOCK_BUSY;
             }
 #endif
         };


### PR DESCRIPTION
## Summary

Fixes nonblocking TCP socket returning `SOCK_BUSY` even when RX data is available.

## Problem

In the non-IPv6 W5500 path at `Ethernet/socket.c:687-692`, the `#else` branch checked nonblocking mode before checking `recvsize != 0`:
```c
#else
    if (sock_io_mode & (1 << sn)) {   // checked first
        return SOCK_BUSY;
    }
    if (recvsize != 0) {              // checked second — too late
        break;
    }
#endif
```

A nonblocking TCP socket returned `SOCK_BUSY` even when RX data was available. The RX pointer never advanced, so retries could not drain the socket and the receive buffer eventually stalled.

## Fix

Swap the two checks so `recvsize != 0` is evaluated first, matching the ordering already used by the IPv6 branch at lines 679-685:
```c
#else
    if (recvsize != 0) {              // checked first
        break;
    }
    if (sock_io_mode & (1 << sn)) {   // checked second
        return SOCK_BUSY;
    }
#endif
```

## Verification

- Multi-chip compile check: passes for all 7 `_WIZCHIP_` values
- An empty nonblocking socket still returns `SOCK_BUSY` (the check is still present, just reordered)