### PR TITLE
fix: stop ctlwizchip() from dereferencing NULL arguments (AUD-005)

### DIFF
--- a/Ethernet/wizchip_conf.c
+++ b/Ethernet/wizchip_conf.c
@@ -431,37 +431,42 @@ void reg_wizchip_qspi_cbfunc(void (*qspi_rb)(uint8_t opcode, uint16_t addr, uint
 #endif
 
 int8_t ctlwizchip(ctlwizchip_type cwtype, void* arg) {
-    //teddy 240122
-#if	_WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5500 || _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
-    uint8_t tmp = *(uint8_t*) arg;
-#endif
     uint8_t* ptmp[2] = {0, 0};
     switch (cwtype) {
         //teddy 240122
 #if _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
     case CW_SYS_LOCK:
-        if (tmp & SYS_CHIP_LOCK) {
-            CHIPLOCK();
-        }
-        if (tmp & SYS_NET_LOCK) {
-            NETLOCK();
-        }
-        if (tmp & SYS_PHY_LOCK) {
-            PHYLOCK();
+        if (arg == 0) return -1;
+        {
+            uint8_t tmp = *(uint8_t*)arg;
+            if (tmp & SYS_CHIP_LOCK) {
+                CHIPLOCK();
+            }
+            if (tmp & SYS_NET_LOCK) {
+                NETLOCK();
+            }
+            if (tmp & SYS_PHY_LOCK) {
+                PHYLOCK();
+            }
         }
         break;
     case CW_SYS_UNLOCK:
-        if (tmp & SYS_CHIP_LOCK) {
-            CHIPUNLOCK();
-        }
-        if (tmp & SYS_NET_LOCK) {
-            NETUNLOCK();
-        }
-        if (tmp & SYS_PHY_LOCK) {
-            PHYUNLOCK();
+        if (arg == 0) return -1;
+        {
+            uint8_t tmp = *(uint8_t*)arg;
+            if (tmp & SYS_CHIP_LOCK) {
+                CHIPUNLOCK();
+            }
+            if (tmp & SYS_NET_LOCK) {
+                NETUNLOCK();
+            }
+            if (tmp & SYS_PHY_LOCK) {
+                PHYUNLOCK();
+            }
         }
         break;
     case CW_GET_SYSLOCK:
+        if (arg == 0) return -1;
         *(uint8_t*)arg = getSYSR() >> 5;
         break;
 #endif
@@ -554,18 +559,24 @@ int8_t ctlwizchip(ctlwizchip_type cwtype, void* arg) {
         //teddy 240122
 #if _WIZCHIP_ == W5100S || _WIZCHIP_ == W5200 || _WIZCHIP_ == W5500 || _WIZCHIP_ == W6100 || _WIZCHIP_ == W6300
     case CW_GET_PHYPOWMODE:
-        tmp = wizphy_getphypmode();
-        if ((int8_t)tmp == -1) {
-            return -1;
+        if (arg == 0) return -1;
+        {
+            uint8_t tmp = wizphy_getphypmode();
+            if ((int8_t)tmp == -1) {
+                return -1;
+            }
+            *(uint8_t*)arg = tmp;
         }
-        *(uint8_t*)arg = tmp;
         break;
     case CW_GET_PHYLINK:
-        tmp = wizphy_getphylink();
-        if ((int8_t)tmp == -1) {
-            return -1;
+        if (arg == 0) return -1;
+        {
+            uint8_t tmp = wizphy_getphylink();
+            if ((int8_t)tmp == -1) {
+                return -1;
+            }
+            *(uint8_t*)arg = tmp;
         }
-        *(uint8_t*)arg = tmp;
         break;
 #endif
     default:


### PR DESCRIPTION
## Summary

Fixes unconditional NULL dereference in `ctlwizchip()` for documented no-argument commands.

## Problem

`Ethernet/wizchip_conf.c:436` unconditionally evaluated `uint8_t tmp = *(uint8_t*) arg` before dispatching to the command case:
```c
int8_t ctlwizchip(ctlwizchip_type cwtype, void* arg) {
    uint8_t tmp = *(uint8_t*) arg;   // <-- dereferences before dispatch
    ...
    case CW_RESET_WIZCHIP:            // requires no argument
        wizchip_sw_reset();
        break;
    case CW_INIT_WIZCHIP:             // explicitly supports arg == NULL
        if (arg != 0) { ... }
```

`CW_RESET_WIZCHIP` requires no argument and `CW_INIT_WIZCHIP` explicitly supports `arg == NULL` for default socket buffers, so a documented no-argument call could dereference NULL.

## Fix

- Remove the unconditional `uint8_t tmp = *(uint8_t*) arg` at the top of the function
- Move guarded dereferences inside only the cases that require `arg`:
  - `CW_SYS_LOCK`, `CW_SYS_UNLOCK`, `CW_GET_SYSLOCK` (W6100/W6300)
  - `CW_GET_PHYPOWMODE`, `CW_GET_PHYLINK` (W5100S/W5200/W5500/W6100/W6300)
- Each case returns `-1` when `arg == NULL`
- `CW_RESET_WIZCHIP` and `CW_INIT_WIZCHIP` proceed without dereferencing

## Verification

- Multi-chip compile check: passes for all 7 `_WIZCHIP_` values
- ASan/UBSan: `ctlwizchip(CW_RESET_WIZCHIP, NULL)` and `ctlwizchip(CW_INIT_WIZCHIP, NULL)` do not fault; `CW_SYS_LOCK` with NULL returns `-1`